### PR TITLE
add django-crispy-forms to requirements textfile for heroku

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ black
 flake8
 coverage
 coveralls
+django-crispy-forms


### PR DESCRIPTION
This pull request adds crispy forms to the `requirements.txt` file to fix the build for: [https://outdoor-squad-integration.herokuapp.com/](https://outdoor-squad-integration.herokuapp.com/)