### PR TITLE
fix: remove white space from bottom of page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,7 @@
   html, body {
     background-image: url("https://i.ibb.co/zZRS5GM/pexels-digital-buggu-186405.jpg");
     background-repeat: no-repeat;
+    background-attachment: fixed;
     background-size: cover;
     height: 100%;
   }

--- a/templates/maps/activity.html
+++ b/templates/maps/activity.html
@@ -5,6 +5,7 @@
   <link href="https://api.mapbox.com/mapbox-gl-js/v2.5.1/mapbox-gl.css" rel="stylesheet">
   <script src="https://api.mapbox.com/mapbox-gl-js/v2.5.1/mapbox-gl.js"></script>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css">
 {% endblock %}
 
 {% block content %}

--- a/templates/maps/map.html
+++ b/templates/maps/map.html
@@ -5,6 +5,7 @@
   <link href="https://api.mapbox.com/mapbox-gl-js/v2.5.1/mapbox-gl.css" rel="stylesheet">
   <script src="https://api.mapbox.com/mapbox-gl-js/v2.5.1/mapbox-gl.js"></script>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This PR removes the white space that appears from scrolling within the app (for example on the events page) and also adds icons to the nav bar at the top of the map pages
![Screen Shot 2021-12-07 at 11 10 57 PM](https://user-images.githubusercontent.com/21378515/145146888-535ec36a-c12c-4ce2-b37f-2c90509d4312.png)
